### PR TITLE
Specify alpha channel.

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,12 @@
                   </ol>
                 </li>
               </ol>
+              <p>
+                When adding new frames to <var>track</var> containing what was painted to the
+                canvas, alpha channel content of the canvas must be captured and preserved if the
+                canvas is not fully opaque. The consumers of this <code>track</code> might not
+                preserve the alpha channel.
+              </p>
               <p class="note">
                 This algorithm results in a captured track not starting until something changes in
                 the canvas.

--- a/index.html
+++ b/index.html
@@ -308,8 +308,8 @@
               </ol>
               <p>
                 When adding new frames to <var>track</var> containing what was painted to the
-                canvas, alpha channel content of the canvas must be captured and preserved if the
-                canvas is not fully opaque. The consumers of this <code>track</code> might not
+                canvas, the alpha channel content of the canvas must be captured and preserved if
+                the canvas is not fully opaque. The consumers of this <code>track</code> might not
                 preserve the alpha channel.
               </p>
               <p class="note">

--- a/index.html
+++ b/index.html
@@ -331,6 +331,8 @@
                   painted, and if the <code><a>frameCaptureRequested</a></code>
                   internal property of <var>track</var> is set, add a new frame
                   to <var>track</var> containing what was painted to the canvas.
+                  The captured frame should preserve the alpha channel if canvas
+                  is not opaque.
                 </li>
                 <li>
                   If a <code>frameRate</code> value was specified, set


### PR DESCRIPTION
Addressing issue [Must the alpha channel be preserved, and what about encoding in an alpha-less format? #30](https://github.com/w3c/mediacapture-fromelement/issues/30).
