### PR TITLE
Remove duplicate info on method parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,45 +308,6 @@
                 This algorithm results in a captured track not starting until something changes in
                 the canvas.
               </p>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Type
-                    </th>
-                    <th>
-                      Nullable
-                    </th>
-                    <th>
-                      Optional
-                    </th>
-                    <th>
-                      Description
-                    </th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">
-                      frameRequestRate
-                    </td>
-                    <td class="prmType">
-                      <code>double</code>
-                    </td>
-                    <td class="prmNullFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmOptTrue">
-                      <span role="img" aria-label="True">✔</span>
-                    </td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> {{MediaStream}}
-              </div>
             </dd>
           </dl>
         </section>
@@ -401,12 +362,6 @@
                   error feedback if the canvas is not origin-clean. In part, this is because we
                   don't track where requests for frames come from. Do we want to highlight that?
                 </p>
-                <div>
-                  <em>No parameters.</em>
-                </div>
-                <div>
-                  <em>Return type:</em> <code>undefined</code>
-                </div>
               </dd>
             </dl>
           </section>


### PR DESCRIPTION
These were inherited from the previous respec WebIDL format, but they now represent a maintenance footgun
See also https://github.com/w3c/webrtc-pc/pull/1450