### PR TITLE
Revert "Add note about Webgl using preserveDrawingBuffer."

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,11 +318,6 @@
                 This algorithm results in a captured track not starting until something changes in
                 the canvas.
               </p>
-              <p class="note">
-                For <a href="http://www.khronos.org/registry/webgl/specs/latest/">WebGL</a>-rendered
-                canvases, <code>preserveDrawingBuffer</code> must be set to <code>true</code> in order
-                for <code><dfn>captureStream</dfn>()</code> to work reliably.
-              </p>
               <table class="parameters">
                 <tbody>
                   <tr>


### PR DESCRIPTION
This reverts commit 8aa65a1657d1a828cb24bab13155b30868f333a5.

Needing preserveDrawingBuffer is an implementation detail, not required by the
spec. This reverts pull request #75.